### PR TITLE
allow working directly from a URL in addition to a file

### DIFF
--- a/which_tests_did_not_complete.py
+++ b/which_tests_did_not_complete.py
@@ -1,19 +1,30 @@
 import sys
 import re
+from urllib2 import urlopen, Request
+
 
 if (len(sys.argv) < 2):
-    print("Usage: which_tests_did_not_complete.py <task_logs.txt>")
+    print("Usage: which_tests_did_not_complete.py <file or url>")
     sys.exit(0)
 
 filename = sys.argv[1]
 
+def handle(filename):
+    if filename.startswith("http://") or filename.startswith("https://"):
+        request = Request(filename, headers={"Accept" : "text/plain"})
+        response = urlopen(request)
+        for line in response:
+            yield line
+    else:
+        with open(filename) as f:
+            for line in f:
+                yield line
+
+
 started_tests = []
 completed_tests = []
 
-with open(filename) as f:
-    content = f.readlines();
-
-for line in content:
+for line in handle(filename):
     m = re.search("Running .*\.js", line)
     if m:
         started_tests.append(m.group(0)[len("Running "):])
@@ -24,3 +35,4 @@ for line in content:
 
 print("tests that started but did not complete:")
 print(list(set(started_tests) - set(completed_tests)))
+


### PR DESCRIPTION
This change allows you to just paste the log URL in as the command line argument, so you don't need to download it first.
